### PR TITLE
Ensure number options are actual numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,15 @@ function paginate(query, options, callback) {
   let populate = options.populate;
   let lean = options.lean || false;
   let leanWithId = options.hasOwnProperty('leanWithId') ? options.leanWithId : true;
-  let limit = options.hasOwnProperty('limit') ? options.limit : 10;
+  let limit = options.hasOwnProperty('limit') ? Number(options.limit) : 10;
   let hint = options.hint;
   let page, offset, skip, promises = [];
 
   if (options.hasOwnProperty('offset')) {
-    offset = options.offset;
+    offset = Number(options.offset);
     skip = offset;
   } else if (options.hasOwnProperty('page')) {
-    page = options.page;
+    page = Number(options.page);
     skip = (page - 1) * limit;
   } else {
     page = 1;


### PR DESCRIPTION
Passing `page = '1'` works as expected when paginating, but `next` comes as `'11'` instead of `2`...